### PR TITLE
Update gfx-rs, and fix some window names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,22 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "andrew"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12,14 +25,30 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "approx"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ash"
-version = "0.24.3"
-source = "git+https://github.com/MaikKlein/ash.git?branch=generator#f13e01d02649d8a3b2a2a6b3e9494783e36e8c6f"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,30 +59,36 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.24"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -82,17 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -105,85 +140,73 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cocoa"
-version = "0.17.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "core-graphics"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "core-graphics"
-version = "0.17.0"
+name = "d3d12"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "derivative"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "digest"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,40 +226,35 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "either"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "env_logger"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -276,12 +294,12 @@ name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -295,53 +313,55 @@ dependencies = [
 [[package]]
 name = "gfx-backend-dx12"
 version = "0.1.0"
-source = "git+https://github.com/bzm3r/gfx?branch=all-components#fdef5559bbbe14e36fc44df81401781e18f56bab"
+source = "git+https://github.com/bzm3r/gfx#1ea867b235449c6ff197551df3fb57315eb868b4"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "spirv_cross 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-backend-metal"
 version = "0.1.0"
-source = "git+https://github.com/bzm3r/gfx?branch=all-components#fdef5559bbbe14e36fc44df81401781e18f56bab"
+source = "git+https://github.com/bzm3r/gfx#1ea867b235449c6ff197551df3fb57315eb868b4"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "metal 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metal 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "spirv_cross 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "range-alloc 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-backend-vulkan"
 version = "0.1.0"
-source = "git+https://github.com/bzm3r/gfx?branch=all-components#fdef5559bbbe14e36fc44df81401781e18f56bab"
+source = "git+https://github.com/bzm3r/gfx#1ea867b235449c6ff197551df3fb57315eb868b4"
 dependencies = [
- "ash 0.24.3 (git+https://github.com/MaikKlein/ash.git?branch=generator)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ash 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -349,14 +369,11 @@ dependencies = [
 [[package]]
 name = "gfx-hal"
 version = "0.1.0"
-source = "git+https://github.com/bzm3r/gfx?branch=all-components#fdef5559bbbe14e36fc44df81401781e18f56bab"
+source = "git+https://github.com/bzm3r/gfx#1ea867b235449c6ff197551df3fb57315eb868b4"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,39 +381,31 @@ name = "gfx-hal-tutorial"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-backend-dx12 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "gfx-backend-metal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "gfx-backend-vulkan 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)",
- "glsl-to-spirv 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-dx12 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "gfx-backend-metal 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "gfx-backend-vulkan 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx)",
+ "glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glsl-to-spirv"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "humantime"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -406,15 +415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.43"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -422,25 +428,33 @@ name = "libloading"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "line_drawing"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -448,38 +462,40 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.0.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memmap"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "metal"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc_id 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -491,26 +507,32 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.2.2"
+name = "nix"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num-traits"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -537,7 +559,7 @@ name = "objc_exception"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -549,8 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "owning_ref"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -561,19 +591,20 @@ name = "parking_lot"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -588,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.15"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -601,15 +632,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -619,19 +645,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.2.1"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.0"
+source = "git+https://github.com/bzm3r/gfx#1ea867b235449c6ff197551df3fb57315eb868b4"
+
+[[package]]
 name = "redox_syscall"
-version = "0.1.40"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -639,27 +738,27 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.49 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,17 +766,57 @@ name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusttype"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -687,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -696,13 +835,13 @@ name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,26 +849,27 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-protocols 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "spirv_cross"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -738,58 +878,58 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "stb_truetype"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "storage-map"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.10.8"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -800,8 +940,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -810,7 +950,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -820,12 +960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -843,12 +978,12 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -857,58 +992,70 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wayland-client"
-version = "0.20.12"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-commons"
-version = "0.20.12"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.20.12"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.20.12"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.20.12"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,7 +1072,7 @@ name = "winapi-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -938,37 +1085,29 @@ name = "wincolor"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winit"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wio"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -976,7 +1115,7 @@ name = "x11"
 version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -985,8 +1124,8 @@ name = "x11-dl"
 version = "2.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -995,134 +1134,152 @@ name = "xcb"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.7.0"
+name = "xdg"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "62ea7024f6f4d203bede7c0c9cdafa3cbda3a9e0fa04d349008496cc95b8f11b"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+"checksum approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c57ff1a5b00753647aebbbcf4ea67fa1e711a65ea7a30eb90dbf07de2485aee"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
-"checksum ash 0.24.3 (git+https://github.com/MaikKlein/ash.git?branch=generator)" = "<none>"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum ash 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88d7c3a310cc01f626d671c9cc1fdacf59c0bdec2bbcbd984301cb802d2ebb37"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
-"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "704fbf3bb5149daab0afb255dbea24a1f08d2f4099cedb9baab6d470d4c5eefb"
-"checksum cocoa 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cd1afb83b2de9c41e5dfedb2bcccb779d433b958404876009ae4b01746ff23"
-"checksum cocoa 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53a840785348e998a1433d1f9d0b350fd83e91711fae8507c76ce510afc77e72"
-"checksum core-foundation 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc3532ec724375c7cb7ff0a097b714fde180bb1f6ed2ab27cfcd99ffca873cd2"
-"checksum core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3fb15cdbdd9cf8b82d97d0296bb5cd3631bba58d6e31650a002a8e7fb5721f9"
-"checksum core-graphics 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92801c908ea6301ae619ed842a72e01098085fc321b9c2f3f833dad555bba055"
-"checksum core-graphics 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de51fc45f0de4bc07e7ecdb172f0559e0f19ca016a0059577a149b11a2f05324"
-"checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
-"checksum digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b29c278aa8fd30796bd977169e8004b4aa88cdcd2f32a6eb22bc2d5d38df94a"
+"checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
+"checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
+"checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
+"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+"checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
+"checksum d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fda5547c55c93b070d59108464bbfd7d9da9563b2ce78fceefc6430e972a420"
+"checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-"checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
-"checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
+"checksum failure 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e945b93ec214c6e97b520ec6c5d80267fc97af327658ee5b9f35984626e51fbf"
+"checksum failure_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7c395a14ab27b42704e85bf2435c5c51f334ad7a96e16fe23c6e63a1cad6cc12"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)" = "<none>"
-"checksum gfx-backend-metal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)" = "<none>"
-"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)" = "<none>"
-"checksum gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx?branch=all-components)" = "<none>"
-"checksum glsl-to-spirv 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "605de660ba1c76e66ffb94ef480f5f6b8c00f5a586fc5cebca1af9ac3e92ab08"
-"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum gfx-backend-dx12 0.1.0 (git+https://github.com/bzm3r/gfx)" = "<none>"
+"checksum gfx-backend-metal 0.1.0 (git+https://github.com/bzm3r/gfx)" = "<none>"
+"checksum gfx-backend-vulkan 0.1.0 (git+https://github.com/bzm3r/gfx)" = "<none>"
+"checksum gfx-hal 0.1.0 (git+https://github.com/bzm3r/gfx)" = "<none>"
+"checksum glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "28caebc98746d507603a2d3df66dcbe04e41d4febad0320f3eec1ef72b6bbef1"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
-"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
+"checksum line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
-"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
-"checksum metal 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76bcb2aba806e52a685c6e55188f7b3152c2019cf6ed86725d8a268c6fecf56c"
+"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
+"checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+"checksum metal 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7de9c2b83c946ab01c9942928388f911d93486b97636d9927541345905fea65d"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
-"checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"
-"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
+"checksum nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "921f61dc817b379d0834e45d5ec45beaacfae97082090a49c2cf30dcbc30206f"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
 "checksum objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
 "checksum objc_exception 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "098cd29a2fa3c230d3463ae069cecccc3fdfd64c0d2496ab5b96f82dab6a00dc"
 "checksum objc_id 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+"checksum ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
-"checksum parking_lot_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06a2b6aae052309c2fd2161ef58f5067bc17bb758377a0de9d4b279d603fdd8a"
+"checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "295af93acfb1d5be29c16ca5b3f82d863836efd9cb0c14fd83811eb9a110e452"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
+"checksum rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
+"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
+"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
+"checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
+"checksum range-alloc 0.1.0 (git+https://github.com/bzm3r/gfx)" = "<none>"
+"checksum redox_syscall 0.1.49 (registry+https://github.com/rust-lang/crates.io-index)" = "f22c50afdcf3f0a31ebb6b47697f6a7c5e5a24967e842858118bce0615f0afad"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "67d0301b0c6804eca7e3c275119d0b01ff3b7ab9258a65709e608a66312a1025"
-"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "436c67ae0d0d24f14e1177c3ed96780ee16db82b405f0fba1bb80b46c9a30625"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-"checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
-"checksum smithay-client-toolkit 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1609083d6bca3991a3c648d80ae16e1764d70881c3321bee1c915149073d605"
-"checksum spirv_cross 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c2c0be48967fec392de4749ac34a2da758aaa359ca648abaa47b90b36845013"
+"checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
+"checksum smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d858330eeed4efaf71c560555e2a6a0597d01b7d52685c3cc964ab1cc360f8c6"
+"checksum spirv_cross 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c38f3b84da9c0439a5898f0697a07c8d59259b9d36c43e4fd5a9a01c38cd80a"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71a7d260b43b6129a22dc341be18a231044ca67a48b7e32625f380cc5ec9ad70"
 "checksum storage-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cb94f167ccba0941876c8e722e888be8b4c05511ffdacc8cfcd4c647adfd424d"
-"checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
-"checksum tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b103c6d08d323b92ff42c8ce62abcd83ca8efa7fd5bf7927efefec75f58c76"
-"checksum termcolor 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3bac0e465b59f194e7037ed404b0326e56ff234d767edc4c5cc9cd49e7a2c7"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wayland-client 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7516a23419a55bd2e6d466c75a6a52c85718e5013660603289c2b8bee794b12"
-"checksum wayland-commons 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)" = "d8609d59b95bf198bae4f3b064d55a712f2d529eec6aac98cc1f6e9cc911d47a"
-"checksum wayland-protocols 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd4d31a96be6ecdbaddbf35200f5af2daee01be592afecd8feaf443d417e9230"
-"checksum wayland-scanner 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e674d85ae9c67cbbc590374d8f2e20a7a02fff87ce3a31fc52213afece8d05ad"
-"checksum wayland-sys 0.20.12 (registry+https://github.com/rust-lang/crates.io-index)" = "87c82ee658aa657fdfd7061f22e442030d921cfefc5bad68bcf41973e67922f7"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
+"checksum wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "267d642a6e551e5af62a5e4fbfaab299221e6ddbd453b5985cfa84c835887679"
+"checksum wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da95f98e6b8222cb0f248811ecd69ba6ebe243b737fd34020f7c73665bb4a3af"
+"checksum wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d20e951995113cdb8f32578c8402e619aa3d3e894f3ca334deb219abc1f6df"
+"checksum wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4f17846a40a19f7917f11c18a6c8c3b3a34b3ba09cb200d3e03503ebdfcbf3a7"
+"checksum wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a0931c24c91e4e56c1119e4137e237df2ccc3696df94f64b1e2f61982d89cc32"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
-"checksum winit 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba44cf306b981badc781894ab5d6fda54764a0512cbbf8db4685d329014143fa"
-"checksum wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a31e8a268d6941ffb7f8d7989fc93e4692bd3e75a27d400a72b4be1dadb213"
+"checksum winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27aa86a5723951d6a08c2acb9f10e25cb39ceb5b1987d7daf74e181b21f8f50b"
 "checksum x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39697e3123f715483d311b5826e254b6f3cfebdd83cf7ef3358f579c3d68e235"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
-"checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
+"checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
+"checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ dx12 = ["gfx-backend-dx12"]
 vulkan = ["gfx-backend-vulkan"]
 
 [dependencies]
-winit = "0.17"
-gfx-hal = { version = "0.1", git = "https://github.com/bzm3r/gfx", branch = "all-components" }
+winit = "0.18"
+gfx-hal = { version = "0.1", git = "https://github.com/bzm3r/gfx", branch = "master" }
 glsl-to-spirv = "0.1.6"
 log = "0.4.0"
 env_logger = "0.5.12"
@@ -19,19 +19,19 @@ env_logger = "0.5.12"
 [dependencies.gfx-backend-vulkan]
 version = "0.1"
 git = "https://github.com/bzm3r/gfx"
-branch = "all-components"
+branch = "master"
 optional = true
 
 [target.'cfg(target_os = "macos")'.dependencies.gfx-backend-metal]
 version = "0.1"
 git = "https://github.com/bzm3r/gfx"
-branch = "all-components"
+branch = "master"
 optional = true
 
 [target.'cfg(windows)'.dependencies.gfx-backend-dx12]
 version = "0.1"
 git = "https://github.com/bzm3r/gfx"
-branch = "all-components"
+branch = "master"
 optional = true
 
 [[bin]]

--- a/src/00_base_code.rs
+++ b/src/00_base_code.rs
@@ -80,4 +80,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/01_instance_creation.rs
+++ b/src/01_instance_creation.rs
@@ -89,4 +89,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/02_validation_layers.rs
+++ b/src/02_validation_layers.rs
@@ -97,4 +97,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/03_physical_device_selection.rs
+++ b/src/03_physical_device_selection.rs
@@ -136,4 +136,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/04_logical_device.rs
+++ b/src/04_logical_device.rs
@@ -138,13 +138,14 @@ impl HelloTriangleApplication {
 
         // we only want to create a single queue
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -175,4 +176,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/05_window_surface.rs
+++ b/src/05_window_surface.rs
@@ -151,16 +151,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -191,4 +193,3 @@ impl HelloTriangleApplication {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/07_image_views.rs
+++ b/src/07_image_views.rs
@@ -20,7 +20,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -43,7 +45,7 @@ struct HalState {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         for (_, image_view) in self.frame_images.into_iter() {
@@ -73,7 +75,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -93,7 +95,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -171,16 +173,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -201,7 +205,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -211,15 +216,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
 
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -247,7 +255,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             // OpenGL case, where backbuffer is a framebuffer, not implemented currently
             _ => unimplemented!(),
         }
@@ -269,8 +278,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/08_graphics_pipeline.rs
+++ b/src/08_graphics_pipeline.rs
@@ -20,7 +20,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -48,7 +50,7 @@ struct HelloTriangleApplication {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         for (_, image_view) in self.frame_images.into_iter() {
@@ -73,7 +75,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -93,7 +95,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -171,16 +173,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -201,7 +205,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -211,15 +216,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
 
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -247,7 +255,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
@@ -290,8 +299,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/10_fixed_functions.rs
+++ b/src/10_fixed_functions.rs
@@ -16,7 +16,7 @@ use hal::{
 use std::io::Read;
 use winit::{dpi, ControlFlow, Event, EventsLoop, Window, WindowBuilder, WindowEvent};
 
-static WINDOW_NAME: &str = "09_shader_modules";
+static WINDOW_NAME: &str = "10_fixed_functions";
 
 fn main() {
     env_logger::init();

--- a/src/10_fixed_functions.rs
+++ b/src/10_fixed_functions.rs
@@ -22,7 +22,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -52,7 +54,7 @@ struct HelloTriangleApplication {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         for descriptor_set_layout in self.descriptor_set_layouts {
@@ -83,7 +85,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -104,7 +106,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -186,16 +188,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -217,7 +221,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -227,15 +232,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
         let extent = swap_config.extent;
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, extent, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -263,12 +271,13 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
 
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         device: &<back::Backend as Backend>::Device,
         extent: window::Extent2D,
     ) -> (
@@ -278,7 +287,8 @@ impl HelloTriangleApplication {
         let vert_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.vert"),
             glsl_to_spirv::ShaderType::Vertex,
-        ).expect("Error compiling vertex shader code.")
+        )
+        .expect("Error compiling vertex shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -286,7 +296,8 @@ impl HelloTriangleApplication {
         let frag_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.frag"),
             glsl_to_spirv::ShaderType::Fragment,
-        ).expect("Error compiling fragment shader code.")
+        )
+        .expect("Error compiling fragment shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -303,12 +314,18 @@ impl HelloTriangleApplication {
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &vert_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &frag_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
             );
 
@@ -388,10 +405,13 @@ impl HelloTriangleApplication {
             // pipeline layout
             let bindings = Vec::<pso::DescriptorSetLayoutBinding>::new();
             let immutable_samplers = Vec::<<back::Backend as Backend>::Sampler>::new();
-            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> =
-                vec![device.create_descriptor_set_layout(bindings, immutable_samplers)];
+            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> = vec![device
+                .create_descriptor_set_layout(bindings, immutable_samplers)
+                .unwrap()];
             let push_constants = Vec::<(pso::ShaderStageFlags, std::ops::Range<u32>)>::new();
-            let layout = device.create_pipeline_layout(&ds_layouts, push_constants);
+            let layout = device
+                .create_pipeline_layout(&ds_layouts, push_constants)
+                .unwrap();
 
             // our goal is to fill out this entire struct
             //    let desc = pso::GraphicsPipelineDesc {
@@ -435,8 +455,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/11_render_passes.rs
+++ b/src/11_render_passes.rs
@@ -16,7 +16,7 @@ use hal::{
 use std::io::Read;
 use winit::{dpi, ControlFlow, Event, EventsLoop, Window, WindowBuilder, WindowEvent};
 
-static WINDOW_NAME: &str = "09_shader_modules";
+static WINDOW_NAME: &str = "11_render_passes";
 
 fn main() {
     env_logger::init();

--- a/src/12_graphics_pipeline_complete.rs
+++ b/src/12_graphics_pipeline_complete.rs
@@ -22,7 +22,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -49,7 +51,7 @@ struct HalState {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         device.destroy_graphics_pipeline(self.gfx_pipeline);
@@ -89,7 +91,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -110,7 +112,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -195,16 +197,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -226,7 +230,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -236,15 +241,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
         let extent = swap_config.extent;
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, extent, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -272,7 +280,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
@@ -310,10 +319,14 @@ impl HelloTriangleApplication {
             preserves: &[],
         };
 
-        device.create_render_pass(&[color_attachment], &[subpass], &[])
+        unsafe {
+            device
+                .create_render_pass(&[color_attachment], &[subpass], &[])
+                .unwrap()
+        }
     }
 
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         device: &<back::Backend as Backend>::Device,
         extent: window::Extent2D,
         render_pass: &<back::Backend as Backend>::RenderPass,
@@ -325,7 +338,8 @@ impl HelloTriangleApplication {
         let vert_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.vert"),
             glsl_to_spirv::ShaderType::Vertex,
-        ).expect("Error compiling vertex shader code.")
+        )
+        .expect("Error compiling vertex shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -333,7 +347,8 @@ impl HelloTriangleApplication {
         let frag_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.frag"),
             glsl_to_spirv::ShaderType::Fragment,
-        ).expect("Error compiling fragment shader code.")
+        )
+        .expect("Error compiling fragment shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -350,12 +365,18 @@ impl HelloTriangleApplication {
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &vert_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &frag_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
             );
 
@@ -429,10 +450,13 @@ impl HelloTriangleApplication {
 
             let bindings = Vec::<pso::DescriptorSetLayoutBinding>::new();
             let immutable_samplers = Vec::<<back::Backend as Backend>::Sampler>::new();
-            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> =
-                vec![device.create_descriptor_set_layout(bindings, immutable_samplers)];
+            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> = vec![device
+                .create_descriptor_set_layout(bindings, immutable_samplers)
+                .unwrap()];
             let push_constants = Vec::<(pso::ShaderStageFlags, std::ops::Range<u32>)>::new();
-            let layout = device.create_pipeline_layout(&ds_layouts, push_constants);
+            let layout = device
+                .create_pipeline_layout(&ds_layouts, push_constants)
+                .unwrap();
 
             let subpass = pass::Subpass {
                 index: 0,
@@ -490,7 +514,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }

--- a/src/12_graphics_pipeline_complete.rs
+++ b/src/12_graphics_pipeline_complete.rs
@@ -16,7 +16,7 @@ use hal::{
 use std::io::Read;
 use winit::{dpi, ControlFlow, Event, EventsLoop, Window, WindowBuilder, WindowEvent};
 
-static WINDOW_NAME: &str = "09_shader_modules";
+static WINDOW_NAME: &str = "12_graphics_pipeline_complete";
 
 fn main() {
     env_logger::init();

--- a/src/13_framebuffers.rs
+++ b/src/13_framebuffers.rs
@@ -22,7 +22,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -50,7 +52,7 @@ struct HalState {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         for framebuffer in self.swapchain_framebuffers {
@@ -94,7 +96,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -115,7 +117,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -207,16 +209,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -238,7 +242,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -248,15 +253,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
         let extent = swap_config.extent;
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, extent, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -284,7 +292,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
@@ -323,10 +332,14 @@ impl HelloTriangleApplication {
             preserves: &[],
         };
 
-        device.create_render_pass(&[color_attachment], &[subpass], &[])
+        unsafe {
+            device
+                .create_render_pass(&[color_attachment], &[subpass], &[])
+                .unwrap()
+        }
     }
 
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         device: &<back::Backend as Backend>::Device,
         extent: window::Extent2D,
         render_pass: &<back::Backend as Backend>::RenderPass,
@@ -338,7 +351,8 @@ impl HelloTriangleApplication {
         let vert_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.vert"),
             glsl_to_spirv::ShaderType::Vertex,
-        ).expect("Error compiling vertex shader code.")
+        )
+        .expect("Error compiling vertex shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -346,7 +360,8 @@ impl HelloTriangleApplication {
         let frag_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.frag"),
             glsl_to_spirv::ShaderType::Fragment,
-        ).expect("Error compiling fragment shader code.")
+        )
+        .expect("Error compiling fragment shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -363,12 +378,18 @@ impl HelloTriangleApplication {
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &vert_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &frag_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
             );
 
@@ -442,10 +463,13 @@ impl HelloTriangleApplication {
 
             let bindings = Vec::<pso::DescriptorSetLayoutBinding>::new();
             let immutable_samplers = Vec::<<back::Backend as Backend>::Sampler>::new();
-            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> =
-                vec![device.create_descriptor_set_layout(bindings, immutable_samplers)];
+            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> = vec![device
+                .create_descriptor_set_layout(bindings, immutable_samplers)
+                .unwrap()];
             let push_constants = Vec::<(pso::ShaderStageFlags, std::ops::Range<u32>)>::new();
-            let layout = device.create_pipeline_layout(&ds_layouts, push_constants);
+            let layout = device
+                .create_pipeline_layout(&ds_layouts, push_constants)
+                .unwrap();
 
             let subpass = pass::Subpass {
                 index: 0,
@@ -498,19 +522,22 @@ impl HelloTriangleApplication {
     ) -> Vec<<back::Backend as Backend>::Framebuffer> {
         let mut swapchain_framebuffers: Vec<<back::Backend as Backend>::Framebuffer> = Vec::new();
 
-        for (_, image_view) in frame_images.iter() {
-            swapchain_framebuffers.push(
-                device
-                    .create_framebuffer(
-                        render_pass,
-                        vec![image_view],
-                        image::Extent {
-                            width: extent.width as _,
-                            height: extent.height as _,
-                            depth: 1,
-                        },
-                    ).expect("failed to create framebuffer!"),
-            );
+        unsafe {
+            for (_, image_view) in frame_images.iter() {
+                swapchain_framebuffers.push(
+                    device
+                        .create_framebuffer(
+                            render_pass,
+                            vec![image_view],
+                            image::Extent {
+                                width: extent.width as _,
+                                height: extent.height as _,
+                                depth: 1,
+                            },
+                        )
+                        .expect("failed to create framebuffer!"),
+                );
+            }
         }
 
         swapchain_framebuffers
@@ -532,8 +559,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }
-

--- a/src/14_command_buffers.rs
+++ b/src/14_command_buffers.rs
@@ -23,7 +23,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -33,7 +35,7 @@ struct WindowState {
 
 struct HalState {
     _submission_command_buffers:
-        Vec<command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>>,
+        Vec<command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>>,
     command_pool: pool::CommandPool<back::Backend, Graphics>,
     swapchain_framebuffers: Vec<<back::Backend as Backend>::Framebuffer>,
     gfx_pipeline: <back::Backend as Backend>::GraphicsPipeline,
@@ -54,7 +56,7 @@ struct HalState {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         device.destroy_command_pool(self.command_pool.into_raw());
@@ -100,7 +102,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -121,7 +123,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -226,16 +228,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -257,7 +261,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -267,15 +272,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
         let extent = swap_config.extent;
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, extent, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -303,7 +311,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
@@ -341,10 +350,14 @@ impl HelloTriangleApplication {
             preserves: &[],
         };
 
-        device.create_render_pass(&[color_attachment], &[subpass], &[])
+        unsafe {
+            device
+                .create_render_pass(&[color_attachment], &[subpass], &[])
+                .unwrap()
+        }
     }
 
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         device: &<back::Backend as Backend>::Device,
         extent: window::Extent2D,
         render_pass: &<back::Backend as Backend>::RenderPass,
@@ -356,7 +369,8 @@ impl HelloTriangleApplication {
         let vert_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.vert"),
             glsl_to_spirv::ShaderType::Vertex,
-        ).expect("Error compiling vertex shader code.")
+        )
+        .expect("Error compiling vertex shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -364,7 +378,8 @@ impl HelloTriangleApplication {
         let frag_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.frag"),
             glsl_to_spirv::ShaderType::Fragment,
-        ).expect("Error compiling fragment shader code.")
+        )
+        .expect("Error compiling fragment shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -381,12 +396,18 @@ impl HelloTriangleApplication {
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &vert_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &frag_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
             );
 
@@ -460,10 +481,13 @@ impl HelloTriangleApplication {
 
             let bindings = Vec::<pso::DescriptorSetLayoutBinding>::new();
             let immutable_samplers = Vec::<<back::Backend as Backend>::Sampler>::new();
-            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> =
-                vec![device.create_descriptor_set_layout(bindings, immutable_samplers)];
+            let ds_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> = vec![device
+                .create_descriptor_set_layout(bindings, immutable_samplers)
+                .unwrap()];
             let push_constants = Vec::<(pso::ShaderStageFlags, std::ops::Range<u32>)>::new();
-            let layout = device.create_pipeline_layout(&ds_layouts, push_constants);
+            let layout = device
+                .create_pipeline_layout(&ds_layouts, push_constants)
+                .unwrap();
 
             let subpass = pass::Subpass {
                 index: 0,
@@ -516,50 +540,54 @@ impl HelloTriangleApplication {
     ) -> Vec<<back::Backend as Backend>::Framebuffer> {
         let mut swapchain_framebuffers: Vec<<back::Backend as Backend>::Framebuffer> = Vec::new();
 
-        for (_, image_view) in frame_images.iter() {
-            swapchain_framebuffers.push(
-                device
-                    .create_framebuffer(
-                        render_pass,
-                        vec![image_view],
-                        image::Extent {
-                            width: extent.width as _,
-                            height: extent.height as _,
-                            depth: 1,
-                        },
-                    ).expect("failed to create framebuffer!"),
-            );
+        unsafe {
+            for (_, image_view) in frame_images.iter() {
+                swapchain_framebuffers.push(
+                    device
+                        .create_framebuffer(
+                            render_pass,
+                            vec![image_view],
+                            image::Extent {
+                                width: extent.width as _,
+                                height: extent.height as _,
+                                depth: 1,
+                            },
+                        )
+                        .expect("failed to create framebuffer!"),
+                );
+            }
         }
 
         swapchain_framebuffers
     }
 
-    fn create_command_buffers<'a>(
+    unsafe fn create_command_buffers<'a>(
         command_pool: &'a mut pool::CommandPool<back::Backend, Graphics>,
         render_pass: &<back::Backend as Backend>::RenderPass,
         framebuffers: &[<back::Backend as Backend>::Framebuffer],
         extent: window::Extent2D,
         pipeline: &<back::Backend as Backend>::GraphicsPipeline,
-    ) -> Vec<command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>> {
-        // reserve (allocate memory for) primary command buffers
-        command_pool.reserve(framebuffers.iter().count());
+    ) -> Vec<command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>>
+    {
+        // pre-allocating memory primary command buffers is not necessary: HAL handles automatically
 
         let mut submission_command_buffers: Vec<
-            command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>,
+            command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>,
         > = Vec::new();
 
         for fb in framebuffers.iter() {
             // command buffer will be returned in 'recording' state
             // Shot: how many times a command buffer can be submitted; we want MultiShot (allow submission multiple times)
             // Level: command buffer type (primary or secondary)
-            // allow_pending_resubmit is set to true, as we want to allow simultaneous use per vulkan-tutorial
             let mut command_buffer: command::CommandBuffer<
                 back::Backend,
                 Graphics,
                 command::MultiShot,
                 command::Primary,
-            > = command_pool.acquire_command_buffer(true);
+            > = command_pool.acquire_command_buffer();
 
+            // allow_pending_resubmit to be true, per vulkan-tutorial
+            command_buffer.begin(true);
             command_buffer.bind_graphics_pipeline(pipeline);
             {
                 // begin render pass
@@ -587,26 +615,27 @@ impl HelloTriangleApplication {
                 render_pass_inline_encoder.draw(0..3, 0..1);
             }
 
-            let submission_command_buffer = command_buffer.finish();
-            submission_command_buffers.push(submission_command_buffer);
+            command_buffer.finish();
+            submission_command_buffers.push(command_buffer);
         }
 
         submission_command_buffers
     }
 
-    fn create_command_pool(
+    unsafe fn create_command_pool(
         device: &<back::Backend as Backend>::Device,
         queue_type: queue::QueueType,
         qf_id: queue::family::QueueFamilyId,
     ) -> pool::CommandPool<back::Backend, Graphics> {
         // raw command pool: a thin wrapper around command pools
         // strongly typed command pool: a safe wrapper around command pools, which ensures that only one command buffer is recorded at the same time from the current queue
-        let raw_command_pool =
-            device.create_command_pool(qf_id, pool::CommandPoolCreateFlags::empty());
+        let raw_command_pool = device
+            .create_command_pool(qf_id, pool::CommandPoolCreateFlags::empty())
+            .unwrap();
 
         // safety check necessary before creating a strongly typed command pool
         assert_eq!(Graphics::supported_by(queue_type), true);
-        unsafe { pool::CommandPool::new(raw_command_pool) }
+        pool::CommandPool::new(raw_command_pool)
     }
 
     fn main_loop(&mut self) {
@@ -625,7 +654,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }

--- a/src/15_hello_triangle.rs
+++ b/src/15_hello_triangle.rs
@@ -17,7 +17,7 @@ use hal::{
 use std::io::Read;
 use winit::{dpi, ControlFlow, Event, EventsLoop, Window, WindowBuilder, WindowEvent};
 
-static WINDOW_NAME: &str = "15_shader_modules";
+static WINDOW_NAME: &str = "15_hello_triangle";
 const MAX_FRAMES_IN_FLIGHT: usize = 2;
 
 fn main() {

--- a/src/15_hello_triangle.rs
+++ b/src/15_hello_triangle.rs
@@ -24,7 +24,9 @@ fn main() {
     env_logger::init();
     let mut application = HelloTriangleApplication::init();
     application.run();
-    application.clean_up();
+    unsafe {
+        application.clean_up();
+    }
 }
 
 struct WindowState {
@@ -37,7 +39,7 @@ struct HalState {
     render_finished_semaphores: Vec<<back::Backend as Backend>::Semaphore>,
     image_available_semaphores: Vec<<back::Backend as Backend>::Semaphore>,
     submission_command_buffers:
-        Vec<command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>>,
+        Vec<command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>>,
     command_pool: pool::CommandPool<back::Backend, Graphics>,
     swapchain_framebuffers: Vec<<back::Backend as Backend>::Framebuffer>,
     gfx_pipeline: <back::Backend as Backend>::GraphicsPipeline,
@@ -58,7 +60,7 @@ struct HalState {
 }
 
 impl HalState {
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         let device = &self.device;
 
         for fence in self.in_flight_fences {
@@ -116,7 +118,7 @@ impl QueueFamilyIds {
 impl HelloTriangleApplication {
     pub fn init() -> HelloTriangleApplication {
         let window_state = HelloTriangleApplication::init_window();
-        let hal_state = HelloTriangleApplication::init_hal(&window_state.window);
+        let hal_state = unsafe { HelloTriangleApplication::init_hal(&window_state.window) };
 
         HelloTriangleApplication {
             hal_state,
@@ -137,7 +139,7 @@ impl HelloTriangleApplication {
         }
     }
 
-    fn init_hal(window: &Window) -> HalState {
+    unsafe fn init_hal(window: &Window) -> HalState {
         let instance = HelloTriangleApplication::create_instance();
         let mut adapter = HelloTriangleApplication::pick_adapter(&instance);
         let mut surface = HelloTriangleApplication::create_surface(&instance, window);
@@ -247,16 +249,18 @@ impl HelloTriangleApplication {
                 Graphics::supported_by(family.queue_type())
                     && family.max_queues() > 0
                     && surface.supports_queue_family(family)
-            }).expect("Could not find a queue family supporting graphics.");
+            })
+            .expect("Could not find a queue family supporting graphics.");
 
         let priorities = vec![1.0; 1];
-
         let families = [(family, priorities.as_slice())];
 
-        let Gpu { device, mut queues } = adapter
-            .physical_device
-            .open(&families)
-            .expect("Could not create device.");
+        let Gpu { device, mut queues } = unsafe {
+            adapter
+                .physical_device
+                .open(&families)
+                .expect("Could not create device.")
+        };
 
         let mut queue_group = queues
             .take::<Graphics>(family.id())
@@ -278,7 +282,8 @@ impl HelloTriangleApplication {
         Backbuffer<back::Backend>,
         format::Format,
     ) {
-        let (caps, formats, _present_modes) = surface.compatibility(&adapter.physical_device);
+        let (caps, formats, _present_modes, _composite_alphas) =
+            surface.compatibility(&adapter.physical_device);
 
         let format = formats.map_or(format::Format::Rgba8Srgb, |formats| {
             formats
@@ -288,15 +293,18 @@ impl HelloTriangleApplication {
                 .unwrap_or(formats[0])
         });
 
-        let swap_config = SwapchainConfig::from_caps(&caps, format);
+        let swap_config = SwapchainConfig::from_caps(&caps, format, caps.extents.end);
         let extent = swap_config.extent;
-        let (swapchain, backbuffer) =
-            device.create_swapchain(surface, swap_config, previous_swapchain);
+        let (swapchain, backbuffer) = unsafe {
+            device
+                .create_swapchain(surface, swap_config, previous_swapchain)
+                .unwrap()
+        };
 
         (swapchain, extent, backbuffer, format)
     }
 
-    fn create_image_views(
+    unsafe fn create_image_views(
         backbuffer: Backbuffer<back::Backend>,
         format: format::Format,
         device: &<back::Backend as Backend>::Device,
@@ -324,7 +332,8 @@ impl HelloTriangleApplication {
                     };
 
                     (image, image_view)
-                }).collect(),
+                })
+                .collect(),
             _ => unimplemented!(),
         }
     }
@@ -363,10 +372,14 @@ impl HelloTriangleApplication {
             preserves: &[],
         };
 
-        device.create_render_pass(&[color_attachment], &[subpass], &[])
+        unsafe {
+            device
+                .create_render_pass(&[color_attachment], &[subpass], &[])
+                .unwrap()
+        }
     }
 
-    fn create_graphics_pipeline(
+    unsafe fn create_graphics_pipeline(
         device: &<back::Backend as Backend>::Device,
         extent: window::Extent2D,
         render_pass: &<back::Backend as Backend>::RenderPass,
@@ -378,7 +391,8 @@ impl HelloTriangleApplication {
         let vert_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.vert"),
             glsl_to_spirv::ShaderType::Vertex,
-        ).expect("Error compiling vertex shader code.")
+        )
+        .expect("Error compiling vertex shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -386,7 +400,8 @@ impl HelloTriangleApplication {
         let frag_shader_code = glsl_to_spirv::compile(
             include_str!("09_shader_base.frag"),
             glsl_to_spirv::ShaderType::Fragment,
-        ).expect("Error compiling fragment shader code.")
+        )
+        .expect("Error compiling fragment shader code.")
         .bytes()
         .map(|b| b.unwrap())
         .collect::<Vec<u8>>();
@@ -403,12 +418,18 @@ impl HelloTriangleApplication {
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &vert_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: "main",
                     module: &frag_shader_module,
-                    specialization: &[],
+                    specialization: hal::pso::Specialization {
+                        constants: &[],
+                        data: &[],
+                    },
                 },
             );
 
@@ -482,11 +503,14 @@ impl HelloTriangleApplication {
 
             let bindings = Vec::<pso::DescriptorSetLayoutBinding>::new();
             let immutable_samplers = Vec::<<back::Backend as Backend>::Sampler>::new();
-            let descriptor_set_layouts: Vec<
-                <back::Backend as Backend>::DescriptorSetLayout,
-            > = vec![device.create_descriptor_set_layout(bindings, immutable_samplers)];
+            let descriptor_set_layouts: Vec<<back::Backend as Backend>::DescriptorSetLayout> =
+                vec![device
+                    .create_descriptor_set_layout(bindings, immutable_samplers)
+                    .unwrap()];
             let push_constants = Vec::<(pso::ShaderStageFlags, std::ops::Range<u32>)>::new();
-            let layout = device.create_pipeline_layout(&descriptor_set_layouts, push_constants);
+            let layout = device
+                .create_pipeline_layout(&descriptor_set_layouts, push_constants)
+                .unwrap();
 
             let subpass = pass::Subpass {
                 index: 0,
@@ -539,36 +563,37 @@ impl HelloTriangleApplication {
     ) -> Vec<<back::Backend as Backend>::Framebuffer> {
         let mut swapchain_framebuffers: Vec<<back::Backend as Backend>::Framebuffer> = Vec::new();
 
-        for (_, image_view) in frame_images.iter() {
-            swapchain_framebuffers.push(
-                device
-                    .create_framebuffer(
-                        render_pass,
-                        vec![image_view],
-                        image::Extent {
-                            width: extent.width as _,
-                            height: extent.height as _,
-                            depth: 1,
-                        },
-                    ).expect("failed to create framebuffer!"),
-            );
+        unsafe {
+            for (_, image_view) in frame_images.iter() {
+                swapchain_framebuffers.push(
+                    device
+                        .create_framebuffer(
+                            render_pass,
+                            vec![image_view],
+                            image::Extent {
+                                width: extent.width as _,
+                                height: extent.height as _,
+                                depth: 1,
+                            },
+                        )
+                        .expect("failed to create framebuffer!"),
+                );
+            }
         }
 
         swapchain_framebuffers
     }
 
-    fn create_command_buffers<'a>(
+    unsafe fn create_command_buffers<'a>(
         command_pool: &'a mut pool::CommandPool<back::Backend, Graphics>,
         render_pass: &<back::Backend as Backend>::RenderPass,
         framebuffers: &[<back::Backend as Backend>::Framebuffer],
         extent: window::Extent2D,
         pipeline: &<back::Backend as Backend>::GraphicsPipeline,
-    ) -> Vec<command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>> {
-        // reserve (allocate memory for) primary command buffers
-        command_pool.reserve(framebuffers.iter().count());
-
+    ) -> Vec<command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>>
+    {
         let mut submission_command_buffers: Vec<
-            command::Submit<back::Backend, Graphics, command::MultiShot, command::Primary>,
+            command::CommandBuffer<back::Backend, Graphics, command::MultiShot, command::Primary>,
         > = Vec::new();
 
         for fb in framebuffers.iter() {
@@ -577,8 +602,9 @@ impl HelloTriangleApplication {
                 Graphics,
                 command::MultiShot,
                 command::Primary,
-            > = command_pool.acquire_command_buffer(true);
+            > = command_pool.acquire_command_buffer();
 
+            command_buffer.begin(true);
             command_buffer.bind_graphics_pipeline(pipeline);
             {
                 // begin render pass
@@ -601,32 +627,33 @@ impl HelloTriangleApplication {
 
                 render_pass_inline_encoder.draw(0..3, 0..1);
             }
+            command_buffer.finish();
 
-            let submission_command_buffer = command_buffer.finish();
-            submission_command_buffers.push(submission_command_buffer);
+            submission_command_buffers.push(command_buffer);
         }
 
         submission_command_buffers
     }
 
-    fn create_command_pool(
+    unsafe fn create_command_pool(
         device: &<back::Backend as Backend>::Device,
         queue_type: queue::QueueType,
         qf_id: queue::family::QueueFamilyId,
     ) -> pool::CommandPool<back::Backend, Graphics> {
-        let raw_command_pool =
-            device.create_command_pool(qf_id, pool::CommandPoolCreateFlags::empty());
+        let raw_command_pool = device
+            .create_command_pool(qf_id, pool::CommandPoolCreateFlags::empty())
+            .unwrap();
 
         // safety check necessary before creating a strongly typed command pool
         assert_eq!(Graphics::supported_by(queue_type), true);
-        unsafe { pool::CommandPool::new(raw_command_pool) }
+        pool::CommandPool::new(raw_command_pool)
     }
 
-    fn draw_frame(
+    unsafe fn draw_frame(
         device: &<back::Backend as Backend>::Device,
         command_queues: &mut [queue::CommandQueue<back::Backend, Graphics>],
         swapchain: &mut <back::Backend as Backend>::Swapchain,
-        submission_command_buffers: &[command::Submit<
+        submission_command_buffers: &[command::CommandBuffer<
             back::Backend,
             Graphics,
             command::MultiShot,
@@ -636,21 +663,27 @@ impl HelloTriangleApplication {
         render_finished_semaphore: &<back::Backend as Backend>::Semaphore,
         in_flight_fence: &<back::Backend as Backend>::Fence,
     ) {
-        device.wait_for_fence(in_flight_fence, std::u64::MAX);
-        device.reset_fence(in_flight_fence);
+        device
+            .wait_for_fence(in_flight_fence, std::u64::MAX)
+            .unwrap();
+        device.reset_fence(in_flight_fence).unwrap();
 
         let image_index = swapchain
             .acquire_image(
                 std::u64::MAX,
                 window::FrameSync::Semaphore(image_available_semaphore),
-            ).expect("could not acquire image!");
+            )
+            .expect("could not acquire image!");
 
-        let submission = queue::submission::Submission::new()
-            .wait_on(&[(
+        let i = image_index as usize;
+        let submission = queue::Submission {
+            command_buffers: &submission_command_buffers[i..i + 1],
+            wait_semaphores: vec![(
                 image_available_semaphore,
                 pso::PipelineStage::COLOR_ATTACHMENT_OUTPUT,
-            )]).signal(vec![render_finished_semaphore])
-            .submit(Some(&submission_command_buffers[image_index as usize]));
+            )],
+            signal_semaphores: vec![render_finished_semaphore],
+        };
 
         // recall we only made one queue
         command_queues[0].submit(submission, Some(in_flight_fence));
@@ -660,7 +693,8 @@ impl HelloTriangleApplication {
                 &mut command_queues[0],
                 image_index,
                 vec![render_finished_semaphore],
-            ).expect("presentation failed!");
+            )
+            .expect("presentation failed!");
     }
 
     fn create_sync_objects(
@@ -675,9 +709,9 @@ impl HelloTriangleApplication {
         let mut in_flight_fences: Vec<<back::Backend as Backend>::Fence> = Vec::new();
 
         for _ in 0..MAX_FRAMES_IN_FLIGHT {
-            image_available_semaphores.push(device.create_semaphore());
-            render_finished_semaphores.push(device.create_semaphore());
-            in_flight_fences.push(device.create_fence(true));
+            image_available_semaphores.push(device.create_semaphore().unwrap());
+            render_finished_semaphores.push(device.create_semaphore().unwrap());
+            in_flight_fences.push(device.create_fence(true).unwrap());
         }
 
         (
@@ -707,15 +741,17 @@ impl HelloTriangleApplication {
                 ControlFlow::Break
             }
             _ => {
-                HelloTriangleApplication::draw_frame(
-                    &self.hal_state.device,
-                    &mut self.hal_state.command_queues,
-                    &mut self.hal_state.swapchain,
-                    &self.hal_state.submission_command_buffers,
-                    &self.hal_state.image_available_semaphores[current_frame],
-                    &self.hal_state.render_finished_semaphores[current_frame],
-                    &self.hal_state.in_flight_fences[current_frame],
-                );
+                unsafe {
+                    HelloTriangleApplication::draw_frame(
+                        &self.hal_state.device,
+                        &mut self.hal_state.command_queues,
+                        &mut self.hal_state.swapchain,
+                        &self.hal_state.submission_command_buffers,
+                        &self.hal_state.image_available_semaphores[current_frame],
+                        &self.hal_state.render_finished_semaphores[current_frame],
+                        &self.hal_state.in_flight_fences[current_frame],
+                    );
+                }
 
                 current_frame = (current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
                 ;
@@ -729,7 +765,7 @@ impl HelloTriangleApplication {
         self.main_loop();
     }
 
-    fn clean_up(self) {
+    unsafe fn clean_up(self) {
         self.hal_state.clean_up();
     }
 }


### PR DESCRIPTION
My gfx-rs fork's master is synced with main, but uses debug-utils (which I have submitted a PR for on gfx-rs main). Pretty soon, we can just point to gfx-rs directly!